### PR TITLE
Conditionally register data source admin

### DIFF
--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -1,13 +1,18 @@
+import swapper
 from django.contrib import admin
 
 from .forms import OrganizationForm
 from .models import OrganizationClass, Organization
 from .utils import get_data_source_model
 
-
-@admin.register(get_data_source_model())
-class DataSourceAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name')
+data_source_model = swapper.get_model_name('django_orghierarchy', 'DataSource')
+# Only register admin when using default data source model
+# When the data source model is swapped, client code should
+# be responsible for creating admin page for the model
+if data_source_model == 'django_orghierarchy.DataSource':
+    @admin.register(get_data_source_model())
+    class DataSourceAdmin(admin.ModelAdmin):
+        list_display = ('id', 'name')
 
 
 @admin.register(OrganizationClass)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,10 +1,18 @@
+from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase, RequestFactory
 
 from django_orghierarchy.admin import OrganizationAdmin
-from django_orghierarchy.models import Organization
+from django_orghierarchy.models import DataSource, Organization
 from .factories import OrganizationFactory
 from .utils import make_admin
+
+
+class TestDataSourceAdmin(TestCase):
+
+    def test_data_source_admin_is_registered(self):
+        is_registered = admin.site.is_registered(DataSource)
+        self.assertTrue(is_registered)
 
 
 class TestOrganizationAdmin(TestCase):

--- a/tests/test_app/tests/test_custom_data_source.py
+++ b/tests/test_app/tests/test_custom_data_source.py
@@ -1,7 +1,8 @@
+from django.contrib import admin
 from django.test import TestCase, tag
 
 from django_orghierarchy import get_data_source_model
-from django_orghierarchy.models import Organization
+from django_orghierarchy.models import DataSource, Organization
 from ..models import CustomDataSource
 
 
@@ -15,3 +16,7 @@ class TestCustomDataSource(TestCase):
     def test_related_data_source_model(self):
         field = Organization._meta.get_field('data_source')
         self.assertIs(field.related_model, CustomDataSource)
+
+    def test_default_data_source_admin_not_registered(self):
+        is_registered = admin.site.is_registered(DataSource)
+        self.assertFalse(is_registered)

--- a/tests/test_app/tests/test_custom_pk_data_source.py
+++ b/tests/test_app/tests/test_custom_pk_data_source.py
@@ -1,7 +1,8 @@
+from django.contrib import admin
 from django.test import TestCase, tag
 
 from django_orghierarchy import get_data_source_model
-from django_orghierarchy.models import Organization
+from django_orghierarchy.models import DataSource, Organization
 from ..models import CustomPrimaryKeyDataSource
 
 
@@ -15,3 +16,7 @@ class TestCustomPrimaryKeyDataSource(TestCase):
     def test_related_data_source_model(self):
         field = Organization._meta.get_field('data_source')
         self.assertIs(field.related_model, CustomPrimaryKeyDataSource)
+
+    def test_default_data_source_admin_not_registered(self):
+        is_registered = admin.site.is_registered(DataSource)
+        self.assertFalse(is_registered)


### PR DESCRIPTION
If the default the data source model is used, then model admin for it is registered. Otherwise the client code should be responsible for registing the swapped data source model.