### PR TITLE
Update user and timestamp auditing field names

### DIFF
--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -34,5 +34,5 @@ class OrganizationAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         if not obj.pk:
             obj.created_by = request.user
-        obj.modified_by = request.user
+        obj.last_modified_by = request.user
         obj.save()

--- a/django_orghierarchy/migrations/0001_initial.py
+++ b/django_orghierarchy/migrations/0001_initial.py
@@ -36,8 +36,8 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(help_text='A primary name, e.g. a legally recognized name', max_length=255)),
                 ('founding_date', models.DateField(blank=True, help_text='A date of founding', null=True)),
                 ('dissolution_date', models.DateField(blank=True, help_text='A date of dissolution', null=True)),
-                ('created_at', models.DateTimeField(auto_now_add=True, help_text='The time at which the resource was created')),
-                ('modified_at', models.DateTimeField(auto_now=True, help_text='The time at which the resource was updated')),
+                ('created_time', models.DateTimeField(auto_now_add=True, help_text='The time at which the resource was created')),
+                ('last_modified_time', models.DateTimeField(auto_now=True, help_text='The time at which the resource was updated')),
                 ('lft', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('rght', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('tree_id', models.PositiveIntegerField(db_index=True, editable=False)),
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='organization',
-            name='modified_by',
+            name='last_modified_by',
             field=models.ForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='modified_organizations', to=settings.AUTH_USER_MODEL),
         ),
         migrations.AddField(

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -61,11 +61,11 @@ class Organization(MPTTModel):
     regular_users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
                                            related_name='organization_memberships')
 
-    created_at = models.DateTimeField(auto_now_add=True, help_text=_('The time at which the resource was created'))
-    modified_at = models.DateTimeField(auto_now=True, help_text=_('The time at which the resource was updated'))
+    created_time = models.DateTimeField(auto_now_add=True, help_text=_('The time at which the resource was created'))
+    last_modified_time = models.DateTimeField(auto_now=True, help_text=_('The time at which the resource was updated'))
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='created_organizations',
                                    null=True, blank=True, editable=False)
-    modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='modified_organizations',
+    last_modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='modified_organizations',
                                     null=True, blank=True, editable=False)
 
     class Meta:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -42,10 +42,10 @@ class TestOrganizationAdmin(TestCase):
         organization = OrganizationFactory.build(classification=organization_class)
         oa.save_model(request, organization, None, None)
         self.assertEqual(organization.created_by, self.admin)
-        self.assertEqual(organization.modified_by, self.admin)
+        self.assertEqual(organization.last_modified_by, self.admin)
 
         another_admin = make_admin(username='another_admin')
         request.user = another_admin
         oa.save_model(request, organization, None, None)
         self.assertEqual(organization.created_by, self.admin)
-        self.assertEqual(organization.modified_by, another_admin)
+        self.assertEqual(organization.last_modified_by, another_admin)


### PR DESCRIPTION
This is due to that linkedevents (which we need to make sure the generic app work with) have code that assume the field are named in specific ways.