### PR TITLE
Remove get_data_source_model from app __init__

### DIFF
--- a/django_orghierarchy/__init__.py
+++ b/django_orghierarchy/__init__.py
@@ -1,7 +1,3 @@
-from .utils import get_data_source_model  # noqa
-
 default_app_config = 'django_orghierarchy.apps.DjangoOrghierarchyConfig'
 
 __version__ = '0.1.1'
-
-__all__ = ['get_data_source_model']

--- a/tests/test_app/tests/test_custom_data_source.py
+++ b/tests/test_app/tests/test_custom_data_source.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.test import TestCase, tag
 
-from django_orghierarchy import get_data_source_model
+from django_orghierarchy.utils import get_data_source_model
 from django_orghierarchy.models import DataSource, Organization
 from ..models import CustomDataSource
 

--- a/tests/test_app/tests/test_custom_pk_data_source.py
+++ b/tests/test_app/tests/test_custom_pk_data_source.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.test import TestCase, tag
 
-from django_orghierarchy import get_data_source_model
+from django_orghierarchy.utils import get_data_source_model
 from django_orghierarchy.models import DataSource, Organization
 from ..models import CustomPrimaryKeyDataSource
 


### PR DESCRIPTION
This way we remove the swapper dependency while importing the package