### PR TITLE
Upgrade to django 2.2

### DIFF
--- a/django_orghierarchy/__init__.py
+++ b/django_orghierarchy/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'django_orghierarchy.apps.DjangoOrghierarchyConfig'
 
-__version__ = '0.1.20'
+__version__ = '0.1.21'

--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -243,6 +243,6 @@ class OrganizationAdmin(DraggableMPTTAdmin):
         actions = super().get_actions(request)
 
         if (not request.user.has_perm('django_orghierarchy.delete_organization')
-            and 'delete_selected' in actions):
+                and 'delete_selected' in actions):
             del actions['delete_selected']
         return actions

--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -113,13 +113,15 @@ class AffiliatedOrganizationInline(SubOrganizationInline):
         return False
 
     def has_change_permission(self, request, obj=None):
-        if request.user.has_perm('django_orghierarchy.change__organization') or request.user.has_perm('django_orghierarchy.change_affiliated_organization'):
+        if (request.user.has_perm('django_orghierarchy.change__organization')
+                or request.user.has_perm('django_orghierarchy.change_affiliated_organization')):
             return True
         return super().has_change_permission(request, obj)
 
     def has_delete_permission(self, request, obj=None):
         # has_change_permission must be True to allow listing, even in read only
-        if request.user.has_perm('django_orghierarchy.delete__organization') or request.user.has_perm('django_orghierarchy.delete_affiliated_organization'):
+        if (request.user.has_perm('django_orghierarchy.delete__organization')
+                or request.user.has_perm('django_orghierarchy.delete_affiliated_organization')):
             return True
         return super().has_delete_permission(request, obj)
 
@@ -136,7 +138,8 @@ class AddAffiliatedOrganizationInline(AddSubOrganizationInline):
         self.fields += ('internal_type',)
 
     def has_add_permission(self, request):
-        if request.user.has_perm('django_orghierarchy.add__organization') or request.user.has_perm('django_orghierarchy.add_affiliated_organization'):
+        if (request.user.has_perm('django_orghierarchy.add__organization')
+                or request.user.has_perm('django_orghierarchy.add_affiliated_organization')):
             return True
         return super().has_add_permission(request)
 
@@ -150,7 +153,8 @@ class ProtectedAffiliatedOrganizationInline(ProtectedSubOrganizationInline):
 
     def has_change_permission(self, request, obj=None):
         # here obj refers to the *parent* organization, change permission to parent is needed
-        if request.user.has_perm('django_orghierarchy.change__organization') or request.user.has_perm('django_orghierarchy.change_affiliated_organization'):
+        if (request.user.has_perm('django_orghierarchy.change__organization')
+                or request.user.has_perm('django_orghierarchy.change_affiliated_organization')):
             return True
         return super().has_change_permission(request, obj)
 
@@ -185,7 +189,10 @@ class OrganizationAdmin(DraggableMPTTAdmin):
         # queryset is already filtered, but write permissions have to be checked based on organization_type
         if obj and obj.internal_type == Organization.AFFILIATED:
             # full rights also cover affiliated organizations
-            has_write_access = request.user.has_perm('django_orghierarchy.change_organization') or request.user.has_perm('django_orghierarchy.change_affiliated_organization')
+            has_write_access = (
+                request.user.has_perm('django_orghierarchy.change_organization')
+                or request.user.has_perm('django_orghierarchy.change_affiliated_organization')
+            )
         else:
             has_write_access = request.user.has_perm('django_orghierarchy.change_organization')
         if obj and not has_write_access:

--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -242,6 +242,7 @@ class OrganizationAdmin(DraggableMPTTAdmin):
     def get_actions(self, request):
         actions = super().get_actions(request)
 
-        if not request.user.has_perm('django_orghierarchy.delete_organization'):
+        if (not request.user.has_perm('django_orghierarchy.delete_organization')
+            and 'delete_selected' in actions):
             del actions['delete_selected']
         return actions

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -87,10 +87,10 @@ class Organization(MPTTModel, DataModel):
     regular_users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
                                            related_name='organization_memberships')
     created_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='created_organizations',
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, related_name='created_organizations',
         null=True, blank=True, editable=False)
     last_modified_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='modified_organizations',
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, related_name='modified_organizations',
         null=True, blank=True, editable=False)
     replaced_by = models.OneToOneField(
         'self', on_delete=models.CASCADE, null=True, blank=True, related_name='replaced_organization',

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -36,7 +36,8 @@ class DataSource(AbstractDataSource):
 
 class DataModel(models.Model):
     id = models.CharField(max_length=255, primary_key=True, editable=False)
-    data_source = models.ForeignKey(swapper.get_model_name('django_orghierarchy', 'DataSource'), blank=True, null=True)
+    data_source = models.ForeignKey(
+        swapper.get_model_name('django_orghierarchy', 'DataSource'), on_delete=models.CASCADE, blank=True, null=True)
     origin_id = models.CharField(max_length=255, blank=True)
     created_time = models.DateTimeField(default=timezone.now, help_text=_('The time at which the resource was created'))
     last_modified_time = models.DateTimeField(auto_now=True, help_text=_('The time at which the resource was updated'))
@@ -80,17 +81,20 @@ class Organization(MPTTModel, DataModel):
     name = models.CharField(max_length=255, help_text=_('A primary name, e.g. a legally recognized name'))
     founding_date = models.DateField(blank=True, null=True, help_text=_('A date of founding'))
     dissolution_date = models.DateField(blank=True, null=True, help_text=_('A date of dissolution'))
-    parent = TreeForeignKey('self', null=True, blank=True, related_name='children',
+    parent = TreeForeignKey('self', on_delete=models.CASCADE, null=True, blank=True, related_name='children',
                             help_text=_('The organizations that contain this organization'))
     admin_users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True, related_name='admin_organizations')
     regular_users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
                                            related_name='organization_memberships')
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='created_organizations',
-                                   null=True, blank=True, editable=False)
-    last_modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='modified_organizations',
-                                         null=True, blank=True, editable=False)
-    replaced_by = models.OneToOneField('self', null=True, blank=True, related_name='replaced_organization',
-                                       help_text=_('The organization that replaces this organization'))
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='created_organizations',
+        null=True, blank=True, editable=False)
+    last_modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='modified_organizations',
+        null=True, blank=True, editable=False)
+    replaced_by = models.OneToOneField(
+        'self', on_delete=models.CASCADE, null=True, blank=True, related_name='replaced_organization',
+        help_text=_('The organization that replaces this organization'))
 
     class Meta:
         unique_together = ('data_source', 'origin_id')

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -93,7 +93,7 @@ class Organization(MPTTModel, DataModel):
         settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, related_name='modified_organizations',
         null=True, blank=True, editable=False)
     replaced_by = models.OneToOneField(
-        'self', on_delete=models.CASCADE, null=True, blank=True, related_name='replaced_organization',
+        'self', on_delete=models.SET_NULL, null=True, blank=True, related_name='replaced_organization',
         help_text=_('The organization that replaces this organization'))
 
     class Meta:

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -129,8 +129,16 @@ class Organization(MPTTModel, DataModel):
                 self.AFFILIATED: 'first-child',
                 self.NORMAL: 'last-child',
             }
-            # we must not call move with original self, its fields were outdated by save
-            new_self.move_to(new_self.parent, move_positions[self.internal_type])
+            position = move_positions[self.internal_type]
+
+            # Only perform move_to if this organization is not already in the correct place
+            # otherwise it would result in an infinite loop.
+            if (
+                (position == 'first-child' and self.get_previous_sibling() is not None)
+                or (position == 'last-child' and self.get_next_sibling() is not None)
+            ):
+                # we must not call move with original self, its fields were outdated by save
+                new_self.move_to(new_self.parent, position)
 
     @property
     def sub_organizations(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=2.2,<3.0
+django<3.0
 django-mptt>=0.9
 djangorestframework
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django<2.0
-django-mptt<0.9
+django>=2.2,<3.0
+django-mptt>=0.9
 djangorestframework
 requests
 swapper

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import TestCase, RequestFactory
 
-from django_orghierarchy.admin import OrganizationAdmin, SubOrganizationInline, AddSubOrganizationInline, ProtectedSubOrganizationInline,\
-    AffiliatedOrganizationInline, AddAffiliatedOrganizationInline, ProtectedAffiliatedOrganizationInline
-from django_orghierarchy.forms import OrganizationForm
+from django_orghierarchy.admin import OrganizationAdmin, SubOrganizationInline, AddSubOrganizationInline,\
+    ProtectedSubOrganizationInline, AffiliatedOrganizationInline, AddAffiliatedOrganizationInline,\
+    ProtectedAffiliatedOrganizationInline
 from django_orghierarchy.models import DataSource, Organization
 from .factories import OrganizationClassFactory, OrganizationFactory, DataSourceFactory
 from .utils import clear_user_perm_cache, make_admin
@@ -432,7 +431,8 @@ class TestOrganizationAdmin(TestCase):
         self.factory = RequestFactory()
 
         self.organization = OrganizationFactory()
-        self.affiliated_organization = OrganizationFactory(internal_type=Organization.AFFILIATED, parent=self.organization)
+        self.affiliated_organization = OrganizationFactory(
+            internal_type=Organization.AFFILIATED, parent=self.organization)
         self.editable_organization = OrganizationFactory(data_source=(DataSourceFactory(user_editable=True)))
 
     def test_get_queryset(self):
@@ -452,7 +452,11 @@ class TestOrganizationAdmin(TestCase):
         # test against superuser admin
         request.user = self.admin
         qs = oa.get_queryset(request)
-        self.assertQuerysetEqual(qs, [repr(self.organization), repr(self.affiliated_organization), repr(self.editable_organization), repr(org), repr(sub_org), repr(another_sub_org)], ordered=False)
+        self.assertQuerysetEqual(
+            qs,
+            [repr(self.organization), repr(self.affiliated_organization), repr(self.editable_organization),
+             repr(org), repr(sub_org), repr(another_sub_org)],
+            ordered=False)
 
         # test against non-superuser admin
         request.user = normal_admin
@@ -465,7 +469,11 @@ class TestOrganizationAdmin(TestCase):
 
         org.admin_users.add(normal_admin)
         qs = oa.get_queryset(request)
-        self.assertQuerysetEqual(qs, [repr(self.organization), repr(self.affiliated_organization), repr(org), repr(sub_org), repr(another_sub_org)], ordered=False)
+        self.assertQuerysetEqual(
+            qs,
+            [repr(self.organization), repr(self.affiliated_organization), repr(org), repr(sub_org),
+             repr(another_sub_org)],
+            ordered=False)
 
     def test_save_model(self):
         oa = OrganizationAdmin(Organization, self.site)
@@ -601,7 +609,8 @@ class TestOrganizationAdmin(TestCase):
         self.assertEqual(fields, oa_protected_readonly_fields + ('replaced_by',))
 
         fields = oa.get_readonly_fields(request, self.editable_organization)
-        self.assertEqual(fields, oa_readonly_fields + ('id', 'data_source', 'origin_id', 'internal_type', 'replaced_by'))
+        self.assertEqual(
+            fields, oa_readonly_fields + ('id', 'data_source', 'origin_id', 'internal_type', 'replaced_by'))
 
         clear_user_perm_cache(normal_admin)
         perm = Permission.objects.get(codename='replace_organization')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,5 +9,5 @@ router.register(r'organization', OrganizationViewSet, 'organization')
 
 urlpatterns = [
     url(r"^admin/", admin.site.urls),
-    url(r'^api/', include(router.urls, namespace='api')),
+    url(r'^api/', include((router.urls, 'api'), namespace='api')),
 ]


### PR DESCRIPTION
Adds support for Django 2.2. I made changes required to have tests pass. The tests still pass with Django 1.11 as well.

I also made sure that the logic of determining if the `move_to` action is necessary for Organizations by fiddling around in Django shell since I wasn't sure if the tests covered that.