### PR TITLE
RATYK-3 | Fix get_queryset returns empty list instead of queryset

### DIFF
--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -176,7 +176,7 @@ class OrganizationAdmin(DraggableMPTTAdmin):
     def get_queryset(self, request):
         if not request.user.is_superuser:
             if not request.user.admin_organizations.all():
-                return []
+                return Organization.objects.none()
             # regular admins have rights to all organizations below their level
             admin_orgs = []
             for admin_org in request.user.admin_organizations.all():

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -452,6 +452,7 @@ class TestOrganizationAdmin(TestCase):
         # test against superuser admin
         request.user = self.admin
         qs = oa.get_queryset(request)
+        self.assertIsInstance(qs, Organization.objects._queryset_class)
         self.assertQuerysetEqual(
             qs,
             [repr(self.organization), repr(self.affiliated_organization), repr(self.editable_organization),
@@ -461,14 +462,17 @@ class TestOrganizationAdmin(TestCase):
         # test against non-superuser admin
         request.user = normal_admin
         qs = oa.get_queryset(request)
+        self.assertIsInstance(qs, Organization.objects._queryset_class)
         self.assertQuerysetEqual(qs, [])
 
         self.organization.admin_users.add(normal_admin)
         qs = oa.get_queryset(request)
+        self.assertIsInstance(qs, Organization.objects._queryset_class)
         self.assertQuerysetEqual(qs, [repr(self.organization), repr(self.affiliated_organization), repr(sub_org)])
 
         org.admin_users.add(normal_admin)
         qs = oa.get_queryset(request)
+        self.assertIsInstance(qs, Organization.objects._queryset_class)
         self.assertQuerysetEqual(
             qs,
             [repr(self.organization), repr(self.affiliated_organization), repr(org), repr(sub_org),


### PR DESCRIPTION
This PR fixes an unfriendly internal server error if a (light) admin who does not have sufficient permissions opened OrganizationAdmin.