### PR TITLE
LINK-1147 | Add organization importer for Open Ahjo 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,40 +84,40 @@ jobs:
   #      with:
   #        args: ". --check"
 
-  #flake8:
-  #  name: Coding style - flake8
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v3
-  #    - name: Set up Python
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.8
-  #
-  #    - name: Install dependencies
-  #      run: pip install flake8 pep8-naming flake8-bugbear
-  #    - name: Run flake8
-  #      uses: liskin/gh-problem-matcher-wrap@v2
-  #      with:
-  #        linters: flake8
-  #        run: flake8
+  flake8:
+    name: Coding style - flake8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-  #isort:
-  #  name: Coding style - isort
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v3
-  #    - name: Set up Python
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.8
-  #
-  #    - name: Install dependencies
-  #      run: pip install isort
-  #    - name: Run isort
-  #      uses: liskin/gh-problem-matcher-wrap@v2
-  #      with:
-  #        linters: isort
-  #        run: isort -c .
+      - name: Install dependencies
+        run: pip install flake8 pep8-naming flake8-bugbear
+      - name: Run flake8
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: flake8
+          run: flake8
+
+  isort:
+    name: Coding style - isort
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: pip install isort
+      - name: Run isort
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: isort
+          run: isort -c .

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ htmlcov
 
 # sqlite db
 db.sqlite3
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_language_version:
+    python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+# TODO to be enabled later
+#  - repo: https://github.com/psf/black
+#    rev: 23.3.0
+#    hooks:
+#      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [pep8-naming, flake8-bugbear]
+        exclude: "migrations"
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        exclude: "migrations"

--- a/README.md
+++ b/README.md
@@ -100,4 +100,3 @@ Run the integration tests.
 pytest -m custom_ds --ds=tests.test_app.settings_custom_ds
 pytest -m custom_pk_ds --ds=tests.test_app.settings_custom_pk_ds
 ```
-

--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -1,12 +1,13 @@
+from functools import reduce
+
 import swapper
 from django.contrib import admin
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from mptt.admin import DraggableMPTTAdmin
-from functools import reduce
 
 from .forms import AffiliatedOrganizationForm, OrganizationForm, SubOrganizationForm
-from .models import OrganizationClass, Organization
+from .models import Organization, OrganizationClass
 from .utils import get_data_source_model
 
 data_source_model = swapper.get_model_name('django_orghierarchy', 'DataSource')

--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -166,13 +166,18 @@ class OrganizationAdmin(DraggableMPTTAdmin):
     form = OrganizationForm
     inlines = [ProtectedSubOrganizationInline, SubOrganizationInline, AddSubOrganizationInline,
                ProtectedAffiliatedOrganizationInline, AffiliatedOrganizationInline, AddAffiliatedOrganizationInline]
-    search_fields = ('name', )
+    search_fields = ('name', 'id', 'origin_id', 'classification__id')
+    list_display = (*DraggableMPTTAdmin.list_display, 'identifier', 'classification_id')
 
     # these fields may not be changed at all in existing organizations
     existing_readonly_fields = ('id', 'data_source', 'origin_id', 'internal_type')
     # these fields may not be changed at all in protected organizations
     protected_readonly_fields = existing_readonly_fields + ('origin_id', 'classification', 'name', 'founding_date',
                                                             'dissolution_date', 'parent',)
+
+    def identifier(self, obj):
+        # Disable sorting on this column
+        return obj.id
 
     def get_queryset(self, request):
         if not request.user.is_superuser:

--- a/django_orghierarchy/forms.py
+++ b/django_orghierarchy/forms.py
@@ -31,8 +31,9 @@ class OrganizationForm(forms.ModelForm):
 
         if 'data_source' in self.fields:
             # Only allow selecting data source within editable sources
-            self.fields['data_source'].queryset = get_data_source_model().objects.filter(user_editable_organizations=True)
-
+            self.fields['data_source'].queryset = (
+                get_data_source_model().objects.filter(user_editable_organizations=True)
+            )
         if 'parent' in self.fields and self.instance.id:
             # prevent recursive reference
             desc_ids = self.instance.get_descendants(include_self=True).values_list('id', flat=True)
@@ -70,7 +71,9 @@ class SubOrganizationForm(forms.ModelForm):
         # the fields can be dynamically exclude, for example set them to readonly in admin
         if 'data_source' in self.fields:
             # Only allow selecting data source within editable sources
-            self.fields['data_source'].queryset = get_data_source_model().objects.filter(user_editable_organizations=True)
+            self.fields['data_source'].queryset = (
+                get_data_source_model().objects.filter(user_editable_organizations=True)
+            )
 
     def clean_internal_type(self):
         return self.initial['internal_type']  # do not allow changing internal_type

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -154,6 +154,7 @@ class RestAPIImporter:
     }
 
     default_config = paatos_config
+    timeout = 10
 
     def __init__(self, url, config=None):
         self.url = url
@@ -413,7 +414,7 @@ class RestAPIImporter:
         """
         logger.info('Start reading data from {0} ...'.format(url))
 
-        r = requests.get(url)
+        r = requests.get(url, timeout=self.timeout)
         try:
             r.raise_for_status()
         except requests.HTTPError as e:
@@ -494,8 +495,7 @@ class RestAPIImporter:
             )
         return data
 
-    @staticmethod
-    def _get_link_data(value):
+    def _get_link_data(self, value):
         """Get data fetched from the link"""
         validator = URLValidator()
         try:
@@ -503,7 +503,7 @@ class RestAPIImporter:
         except ValidationError:
             raise DataImportError('Invalid URL: {0}'.format(value))
 
-        r = requests.get(value)
+        r = requests.get(value, timeout=self.timeout)
 
         try:
             r.raise_for_status()

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import re
+import warnings
 from enum import Enum
 
 import requests
@@ -55,6 +56,7 @@ class RestAPIImporter:
             in organization classes, if present.
         - update_fields: The fields to update if the organization with same origin_id and data
             source exists.
+        - deprecated: Is the configuration considered deprecated. Default False.
         - field_config: Configs for each field. Config options:
             - source_field: The source data object key where the field value comes from.
                 Defaults to original field name.
@@ -97,7 +99,9 @@ class RestAPIImporter:
         }
     """
 
+    # https://api.hel.fi/paatos/v1/organization/
     paatos_config = {
+        'deprecated': True,
         'next_key': 'next',
         'results_key': 'results',
         'fields': [
@@ -180,6 +184,12 @@ class RestAPIImporter:
             'classification': self._import_organization_class,
             'parent': self._import_organization,
         }
+
+        if self.config.get('deprecated', False):
+            warnings.warn(
+                'RestAPIImporter is initialized with a deprecated configuration.',
+                DeprecationWarning, stacklevel=2
+            )
 
         self._organization_classes = {}
         self._data_sources = {}

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -257,10 +257,11 @@ class RestAPIImporter:
         # default data source used if missing
         if 'data_source' not in data or not data['data_source']:
             data['data_source'] = self.default_data_source
+        data_source_instance = self.related_import_methods['data_source'](data['data_source'])
         # reformat id to fit our model
         if not isinstance(identifier, str) or ':' not in identifier:
-            data['id'] = data['data_source'] + ':' + str(identifier)
-        data['data_source'] = self.related_import_methods['data_source'](data['data_source'])
+            data['id'] = data_source_instance.pk + ':' + str(identifier)
+        data['data_source'] = data_source_instance
         # extra fields should not crash the import. Only use specified fields.
         data = {field: value for (field, value) in data.items() if field in supported_fields}
         if identifier not in self._organization_classes:

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -173,7 +173,7 @@ class RestAPIImporter:
                     merged_field_config[field] = default_field_config[field]
             self.config['field_config'] = merged_field_config
             self.config.update(config)
-        logger.info('Importing organization data from %s with the following config:' % self.url)
+        logger.info(f'Importing organization data from {self.url} with the following config:')
         logger.info(self.config)
         self.related_import_methods = {
             'data_source': self._import_data_source,
@@ -322,6 +322,8 @@ class RestAPIImporter:
             data_source = self._get_field_value(
                 {'data_source': self.default_data_source}, 'data_source', {'data_type': 'value'})
 
+        logger.debug(f'Importing Organization: {origin_id}')
+
         # id is never imported in default config
 
         try:
@@ -346,7 +348,7 @@ class RestAPIImporter:
             # processed, to get up to date status of the mptt tree before saving each organization.
             # enforce lower case id standard, but recognize upper case ids as equal:
             organization = Organization.objects.get(origin_id__iexact=origin_id, data_source=data_source)
-            logger.info('Organization already exists: {0}'.format(organization.id))
+            logger.info(f'Updating organization: {origin_id}')
             for field, value in values_to_update.items():
                 setattr(organization, field, value)
             if (
@@ -369,6 +371,7 @@ class RestAPIImporter:
                         continue
                     else:
                         raise
+            logger.info(f'Creating Organization: {origin_id}')
             organization = Organization.objects.create(**object_data)
             if (
                 self.config.get('default_parent_organization', None)
@@ -413,7 +416,7 @@ class RestAPIImporter:
 
         The iterator will follow over next page links if available.
         """
-        logger.info('Start reading data from {0} ...'.format(url))
+        logger.info(f'Start reading data from {url} ...')
 
         r = requests.get(url, timeout=self.timeout)
         try:
@@ -425,7 +428,7 @@ class RestAPIImporter:
         for data_item in data[self.results_key] if self.results_key else data:
             yield data_item
 
-        logger.info('Reading data from {0} completed'.format(url))
+        logger.info(f'Reading data from {url} completed')
 
         if self.next_key and data[self.next_key]:
             next_url = data[self.next_key]

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db import transaction
 
-from .models import OrganizationClass, Organization
+from .models import Organization, OrganizationClass
 from .utils import get_data_source_model
 
 logger = logging.getLogger(__name__)
@@ -428,7 +428,6 @@ class RestAPIImporter:
         if self.next_key and data[self.next_key]:
             next_url = data[self.next_key]
             yield from self._data_iter(next_url)
-
 
     def _get_field_value(self, data_item, field, config):
         """Get source value for the field from the data item

--- a/django_orghierarchy/importers.py
+++ b/django_orghierarchy/importers.py
@@ -265,7 +265,8 @@ class RestAPIImporter:
         # extra fields should not crash the import. Only use specified fields.
         data = {field: value for (field, value) in data.items() if field in supported_fields}
         if identifier not in self._organization_classes:
-            organization_class, _ = OrganizationClass.objects.get_or_create(**data)
+            defaults = {'name': data.pop('name', data['id'])}
+            organization_class, _ = OrganizationClass.objects.get_or_create(**data, defaults=defaults)
             self._organization_classes[identifier] = organization_class
         return self._organization_classes[identifier]
 

--- a/django_orghierarchy/management/commands/import_organizations.py
+++ b/django_orghierarchy/management/commands/import_organizations.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             '--config',
             dest='config',
             default='paatos',
-            choices=['paatos', 'tprek'],
+            choices=['paatos', 'tprek', 'openahjo'],
             help='REST API configuration to use when importing.'
         )
 

--- a/django_orghierarchy/models.py
+++ b/django_orghierarchy/models.py
@@ -15,7 +15,9 @@ class AbstractDataSource(models.Model):
     """
     id = models.CharField(max_length=100, primary_key=True)
     name = models.CharField(max_length=255)
-    user_editable_organizations = models.BooleanField(default=False, verbose_name=_('Organizations may be edited by users'))
+    user_editable_organizations = models.BooleanField(
+        default=False, verbose_name=_('Organizations may be edited by users')
+    )
 
     class Meta:
         abstract = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ factory-boy>=3.1.0
 pytest>=6.1.1
 pytest-cov>=2.10.1
 pytest-django>=3.10.0
+requests-mock>=1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,16 @@
-[pep8]
-max-line-length = 120
-exclude = *migrations*
-ignore = E309
-
 [flake8]
 exclude = .git, build, dist, django_orghierarchy/migrations
 max-line-length = 120
-ignore = W503, W605
+max-complexity = 20
+extend-ignore = W605,E203
+
+[isort]
+profile = black
+atomic = true
+order_by_type = false
+extend_skip_glob = *migrations*
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = tests.settings
+norecursedirs = bower_components node_modules .git .idea test_app
+doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import find_packages, setup
 
 from django_orghierarchy import __version__

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,13 +1,20 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Permission
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
 
-from django_orghierarchy.admin import OrganizationAdmin, SubOrganizationInline, AddSubOrganizationInline,\
-    ProtectedSubOrganizationInline, AffiliatedOrganizationInline, AddAffiliatedOrganizationInline,\
-    ProtectedAffiliatedOrganizationInline
+from django_orghierarchy.admin import (
+    AddAffiliatedOrganizationInline,
+    AddSubOrganizationInline,
+    AffiliatedOrganizationInline,
+    OrganizationAdmin,
+    ProtectedAffiliatedOrganizationInline,
+    ProtectedSubOrganizationInline,
+    SubOrganizationInline,
+)
 from django_orghierarchy.models import DataSource, Organization
-from .factories import OrganizationClassFactory, OrganizationFactory, DataSourceFactory
+
+from .factories import DataSourceFactory, OrganizationClassFactory, OrganizationFactory
 from .utils import clear_user_perm_cache, make_admin
 
 
@@ -433,7 +440,9 @@ class TestOrganizationAdmin(TestCase):
         self.organization = OrganizationFactory()
         self.affiliated_organization = OrganizationFactory(
             internal_type=Organization.AFFILIATED, parent=self.organization)
-        self.editable_organization = OrganizationFactory(data_source=(DataSourceFactory(user_editable_organizations=True)))
+        self.editable_organization = OrganizationFactory(
+            data_source=(DataSourceFactory(user_editable_organizations=True))
+        )
 
     def test_get_queryset(self):
         org = OrganizationFactory()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django_orghierarchy.importers import DataImportError
 from django_orghierarchy.models import Organization, OrganizationClass
 from django_orghierarchy.utils import get_data_source_model
+
 from .test_importers import mock_request_get
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,8 +1,13 @@
 from django.test import TestCase
 
-from django_orghierarchy.forms import OrganizationForm, SubOrganizationForm, AffiliatedOrganizationForm
+from django_orghierarchy.forms import (
+    AffiliatedOrganizationForm,
+    OrganizationForm,
+    SubOrganizationForm,
+)
 from django_orghierarchy.models import Organization
-from .factories import OrganizationClassFactory, DataSourceFactory, OrganizationFactory
+
+from .factories import DataSourceFactory, OrganizationClassFactory, OrganizationFactory
 
 
 class TestOrganizationForm(TestCase):

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -576,7 +576,6 @@ class TestTprekRestApiImporter(TestRestApiImporter):
     @patch('requests.get', MagicMock(side_effect=mock_request_get))
     def test_import_organization_with_missing_parent(self):
         organization = self.importer._import_organization(tprek_organization_3)
-        print(organization)
         qs = Organization.objects.all()
 
         # also created parent organization.

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -98,7 +98,7 @@ tprek_organizations = {
 }
 
 
-def mock_request_get(url):
+def mock_request_get(url, *args, **kwargs):
     m = re.search(r'http://fake.url/organizations/(\d+)/', url)
     if m:
         org_id = m.group(1)
@@ -124,7 +124,7 @@ def mock_request_get(url):
     return MockResponse({}, status_code=404)
 
 
-def mock_tprek_request_get(url):
+def mock_tprek_request_get(url, *args, **kwargs):
     m = re.search(r'http://fake.tprek.url/department/', url)
     if m:
         return MockResponse(tprek_organizations.values())

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -289,6 +289,15 @@ class TestRestApiImporter(TestCase):
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'OpenDecisionAPI:class-with-no-source')
 
+    def test_import_organization_class_with_simple_string_and_remapped_data_source(self):
+        self.importer.config['rename_data_source'] = {'OpenDecisionAPI': 'remapped'}
+
+        organization_class = self.importer._import_organization_class('class-with-no-source')
+
+        qs = OrganizationClass.objects.all()
+        self.assertQuerysetEqual(qs, [repr(organization_class)])
+        self.assertEqual(organization_class.id, 'remapped:class-with-no-source')
+
     def test_import_organization_class_with_dict_data(self):
         data = {
             'id': 999,
@@ -527,6 +536,15 @@ class TestTprekRestApiImporter(TestRestApiImporter):
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'tprek:class-with-no-source')
+
+    def test_import_organization_class_with_simple_string_and_remapped_data_source(self):
+        self.importer.config['rename_data_source'] = {'tprek': 'remapped'}
+
+        organization_class = self.importer._import_organization_class('class-with-no-source')
+
+        qs = OrganizationClass.objects.all()
+        self.assertQuerysetEqual(qs, [repr(organization_class)])
+        self.assertEqual(organization_class.id, 'remapped:class-with-no-source')
 
     def test_import_organization_class_with_dict_data(self):
         pass

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -561,7 +561,11 @@ class TestTprekRestApiImporter(TestRestApiImporter):
 
         # also created parent organization.
         # parent will have the default parent organization
-        self.assertQuerysetEqual(qs, [repr(default_parent), repr(organization.parent), repr(organization)], ordered=False)
+        self.assertQuerysetEqual(
+            qs,
+            [repr(default_parent), repr(organization.parent), repr(organization)],
+            ordered=False
+        )
         self.assertEqual(organization.name, 'Organization-1')
         self.assertEqual(organization.id, 'tprek:111')
         self.assertEqual(organization.parent.name, 'Organization-2')
@@ -604,7 +608,11 @@ class TestTprekRestApiImporter(TestRestApiImporter):
 
         # also created parent organization.
         # parent will have the default parent organization
-        self.assertQuerysetEqual(qs, [repr(default_parent), repr(organization.parent), repr(organization)], ordered=False)
+        self.assertQuerysetEqual(
+            qs,
+            [repr(default_parent), repr(organization.parent), repr(organization)],
+            ordered=False
+        )
         self.assertEqual(organization.name, 'Organization-1')
         self.assertEqual(organization.id, 'tprek:111')
         self.assertEqual(organization.parent.name, 'Organization-2')
@@ -623,7 +631,11 @@ class TestTprekRestApiImporter(TestRestApiImporter):
         new_importer = RestAPIImporter('http://fake.tprek.url/department/', self.config)
         organization = new_importer._import_organization(changed_organization)
         # Now the parents should have switched.
-        self.assertQuerysetEqual(qs, [repr(default_parent), repr(organization.parent), repr(organization)], ordered=False)
+        self.assertQuerysetEqual(
+            qs,
+            [repr(default_parent), repr(organization.parent), repr(organization)],
+            ordered=False
+        )
         self.assertEqual(organization.name, 'Organization-2')
         self.assertEqual(organization.id, 'tprek:222')
         self.assertEqual(organization.parent.name, 'Organization-1')

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -282,12 +282,14 @@ class TestRestApiImporter(TestCase):
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'test-source-1:test-org-class')
+        self.assertEqual(organization_class.name, 'test-source-1:test-org-class')
 
     def test_import_organization_class_with_simple_string(self):
         organization_class = self.importer._import_organization_class('class-with-no-source')
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'OpenDecisionAPI:class-with-no-source')
+        self.assertEqual(organization_class.name, 'OpenDecisionAPI:class-with-no-source')
 
     def test_import_organization_class_with_simple_string_and_remapped_data_source(self):
         self.importer.config['rename_data_source'] = {'OpenDecisionAPI': 'remapped'}
@@ -297,6 +299,7 @@ class TestRestApiImporter(TestCase):
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'remapped:class-with-no-source')
+        self.assertEqual(organization_class.name, 'remapped:class-with-no-source')
 
     def test_import_organization_class_with_dict_data(self):
         data = {
@@ -536,6 +539,7 @@ class TestTprekRestApiImporter(TestRestApiImporter):
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'tprek:class-with-no-source')
+        self.assertEqual(organization_class.name, 'tprek:class-with-no-source')
 
     def test_import_organization_class_with_simple_string_and_remapped_data_source(self):
         self.importer.config['rename_data_source'] = {'tprek': 'remapped'}
@@ -545,6 +549,7 @@ class TestTprekRestApiImporter(TestRestApiImporter):
         qs = OrganizationClass.objects.all()
         self.assertQuerysetEqual(qs, [repr(organization_class)])
         self.assertEqual(organization_class.id, 'remapped:class-with-no-source')
+        self.assertEqual(organization_class.name, 'remapped:class-with-no-source')
 
     def test_import_organization_class_with_dict_data(self):
         pass

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -266,6 +266,18 @@ class TestRestApiImporter(TestCase):
         self.assertQuerysetEqual(Organization.objects.all(), [repr(organization)])
         self.assertEqual(organization.name, 'Organization-2')
 
+    @patch('requests.get', MagicMock(side_effect=mock_request_get))
+    def test_import_organization_data_with_skip_classifications(self):
+        """Organization is not imported if it's in the classification skip list."""
+        self.importer.config["skip_classifications"] = ["test-class-1"]
+        organization = self.importer._import_organization(organization_1)
+        self.assertIsNone(organization)
+
+        # Re-initialize the importer to clear the caches and data
+        importer = self.get_importer()
+        organization = importer._import_organization(organization_1)
+        self.assertEqual(organization.id, "test-source-1:abc-123")
+
     def test_import_data_source_with_string(self):
         data_source = self.importer._import_data_source('test-data-source')
         data_source_model = get_data_source_model()
@@ -571,6 +583,18 @@ class TestTprekRestApiImporter(TestRestApiImporter):
 
     def test_import_data_source_with_dict_data(self):
         pass
+
+    @patch('requests.get', MagicMock(side_effect=mock_tprek_request_get))
+    def test_import_organization_data_with_skip_classifications(self):
+        """Organization is not imported if it's in the classification skip list."""
+        self.importer.config["skip_classifications"] = ["TEST_TYPE_1"]
+        organization = self.importer._import_organization(tprek_organization_1)
+        self.assertIsNone(organization)
+
+        # Re-initialize the importer to clear the caches and data
+        importer = self.get_importer()
+        organization = importer._import_organization(tprek_organization_1)
+        self.assertEqual(organization.id, 'tprek:111')
 
     def test_import_organization_update_existing(self):
         organization = OrganizationFactory(

--- a/tests/test_importers_openahjo.py
+++ b/tests/test_importers_openahjo.py
@@ -1,0 +1,474 @@
+import datetime
+
+import pytest
+from pytest_django.asserts import assertQuerysetEqual
+
+from django_orghierarchy.importers import DataImportError, RestAPIImporter
+from django_orghierarchy.models import Organization, OrganizationClass
+from django_orghierarchy.utils import get_data_source_model
+from tests.factories import OrganizationFactory
+
+req_mock = None
+
+
+@pytest.fixture(autouse=True)
+def global_requests_mock(requests_mock):
+    global req_mock
+    req_mock = requests_mock
+    yield requests_mock
+
+    req_mock = None
+
+
+org_1 = {
+    "abbreviation": "Hki",
+    "classification": None,
+    "created_at": "2014-11-27T20:06:22.404134",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": None,
+    "id": "hel:00001",
+    "name_fi": "Helsingin kaupunki",
+    "name_sv": "Helsingfors stad",
+    "origin_id": "00001",
+    "parents": [],
+    "policymaker": None,
+    "resource_uri": "/paatokset/v1/organization/hel%3A00001/",
+    "slug": "00001",
+    "type": "city",
+    "updated_at": "2014-11-27T20:06:22.408446",
+}
+
+org_2 = {
+    "abbreviation": "Kvsto",
+    "classification": None,
+    "created_at": "2014-11-27T20:06:22.618886",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": None,
+    "id": "hel:02900",
+    "name_fi": "Kaupunginvaltuusto",
+    "name_sv": "Stadsfullmäktige",
+    "origin_id": "02900",
+    "parents": ["/paatokset/v1/organization/hel%3A00001/"],
+    "policymaker": "/paatokset/v1/policymaker/5/",
+    "policymaker_slug": "kvsto",
+    "resource_uri": "/paatokset/v1/organization/hel%3A02900/",
+    "slug": "kvsto",
+    "type": "council",
+    "updated_at": "2017-08-03T11:42:34.949991",
+}
+org_3 = {
+    "abbreviation": "Khs",
+    "classification": None,
+    "created_at": "2014-11-27T20:06:23.355894",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": None,
+    "id": "hel:00400",
+    "name_fi": "Kaupunginhallitus",
+    "name_sv": "Stadsstyrelsen",
+    "origin_id": "00400",
+    "parents": ["/paatokset/v1/organization/hel%3A02900/"],
+    "policymaker": "/paatokset/v1/policymaker/2/",
+    "policymaker_slug": "khs",
+    "resource_uri": "/paatokset/v1/organization/hel%3A00400/",
+    "slug": "khs",
+    "type": "board",
+    "updated_at": "2017-08-03T11:42:34.961049",
+}
+org_4 = {
+    "abbreviation": "Keha",
+    "classification": None,
+    "created_at": "2017-08-03T11:42:42.491738",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": "2017-06-01",
+    "id": "hel:U50",
+    "name_fi": "Keskushallinto",
+    "name_sv": "Centralförvaltningen",
+    "origin_id": "U50",
+    "parents": ["/paatokset/v1/organization/hel%3A00400/"],
+    "policymaker": None,
+    "resource_uri": "/paatokset/v1/organization/hel%3AU50/",
+    "slug": "u50",
+    "type": "field",
+    "updated_at": "2017-08-03T11:42:42.493469",
+}
+org_kanslia = {
+    "abbreviation": "Kanslia",
+    "classification": None,
+    "created_at": "2017-08-03T11:42:42.566923",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": "2018-01-15",
+    "id": "hel:U02100",
+    "name_fi": "Kaupunginkanslia",
+    "name_sv": "Stadskansliet",
+    "origin_id": "U02100",
+    "parents": ["/paatokset/v1/organization/hel%3AU50/"],
+    "policymaker": None,
+    "resource_uri": "/paatokset/v1/organization/hel%3AU02100/",
+    "slug": "u02100",
+    "type": "packaged_service",
+    "updated_at": "2018-02-13T14:06:14.671597",
+}
+org_talpa = {
+    "abbreviation": "Talpa",
+    "classification": None,
+    "created_at": "2017-08-03T11:42:42.526192",
+    "deleted": False,
+    "dissolution_date": None,
+    "founding_date": "2020-03-01",
+    "id": "hel:U01600",
+    "name_fi": "Taloushallintopalveluliikelaitos",
+    "name_sv": "Affärsverket ekonomiförvaltningen",
+    "origin_id": "U01600",
+    "parents": ["/paatokset/v1/organization/hel%3AU50/"],
+    "policymaker": None,
+    "resource_uri": "/paatokset/v1/organization/hel%3AU01600/",
+    "slug": "u01600",
+    "type": "packaged_service",
+    "updated_at": "2022-11-03T16:03:58.790299",
+}
+
+
+def register_responses():
+    response_1 = {
+        "meta": {
+            "limit": 3,
+            "next": "/organization/?limit=3&offset=3",
+            "offset": 0,
+            "previous": None,
+            "total_count": 6,
+        },
+        "objects": [org_1, org_2, org_3],
+    }
+    response_2 = {
+        "meta": {
+            "limit": 3,
+            "next": None,
+            "offset": 3,
+            "previous": "/organization/?limit=3&offset=0",
+            "total_count": 6,
+        },
+        "objects": [org_4, org_kanslia, org_talpa],
+    }
+
+    req_mock.get("http://fake.url/organization/", json=response_1)
+    req_mock.get("http://fake.url/organization/?limit=3&offset=3", json=response_2)
+
+
+@pytest.fixture
+def importer():
+    register_responses()
+    return RestAPIImporter(
+        "http://fake.url/organization/", RestAPIImporter.openahjo_config
+    )
+
+
+def test_expected_importer_configuration(importer):
+    assert importer.has_meta
+    assert importer.next_key == "next"
+    assert importer.results_key == "objects"
+    assert importer.default_data_source == "OpenAhjoAPI"
+
+    expected_field_config = {
+        "classification": {"source_field": "type"},
+        "name": {"source_field": "name_fi"},
+        "origin_id": {"data_type": "str_lower"},
+        "parent": {
+            "data_type": "org_id_regex",
+            "optional": True,
+            "pattern": r"\/(\w+:\w+)\/$",
+            "source_field": "parents",
+            "unquote": True,
+            "unwrap_list": True,
+        },
+    }
+    assert importer.field_config == expected_field_config
+
+
+def test_data_iter(importer):
+    """Test that data_iter returns all items from the API."""
+    iterator = importer._data_iter(importer.url)
+    assert len(list(iterator)) == 6
+
+
+@pytest.mark.parametrize(
+    "resource_id,expected",
+    [
+        (
+            "/organization/?limit=20&offset=20",
+            "http://fake.url/organization/?limit=20&offset=20",
+        ),
+        ("123", "http://fake.url/organization/123"),
+        (
+            "https://identifier-with-host/paatokset/v1/organization/?limit=20",
+            "https://identifier-with-host/paatokset/v1/organization/?limit=20",
+        ),
+    ],
+)
+def test_build_resource_url(importer, resource_id, expected):
+    assert importer._build_resource_url(resource_id) == expected
+
+
+@pytest.mark.django_db
+def test_import_organization_class(importer):
+    """Test that organization class is imported correctly.
+
+    Currently supported types in Open Ahjo API:
+    https://github.com/City-of-Helsinki/openahjo/blob/master/decisions/models.py#L11
+    - council,
+    - board,
+    - board_division,
+    - committee,
+    - field,
+    - department,
+    - division,
+    - introducer,
+    - introducer_field,
+    - office_holder,
+    - trustee,
+    - city,
+    - unit
+    """
+    organization_class = importer._import_organization_class(org_1["type"])
+
+    qs = OrganizationClass.objects.all()
+    assertQuerysetEqual(qs, [repr(organization_class)])
+    assert organization_class.id == f"{importer.default_data_source}:city"
+    assert organization_class.name == f"{importer.default_data_source}:city"
+
+
+@pytest.mark.django_db
+def test_import_organization_class_with_remapped_data_source(
+    importer,
+):
+    importer.config["rename_data_source"] = {
+        f"{importer.default_data_source}": "remapped"
+    }
+
+    organization_class = importer._import_organization_class(org_1["type"])
+
+    qs = OrganizationClass.objects.all()
+    assertQuerysetEqual(qs, [repr(organization_class)])
+    assert organization_class.id == "remapped:city"
+    assert organization_class.name == "remapped:city"
+
+
+@pytest.mark.django_db
+def test_import_data_source(importer):
+    """OpenAhjo API doesn't define a data source, so we use the default one."""
+    data_source = importer._import_data_source(importer.default_data_source)
+
+    data_source_model = get_data_source_model()
+    qs = data_source_model.objects.all()
+    assertQuerysetEqual(qs, [repr(data_source)])
+    assert data_source.id == f"{importer.default_data_source}"
+
+
+@pytest.mark.django_db
+def test_import_data_source_with_remapped_identifier(importer):
+    """Remapping the default data source."""
+    importer.config["rename_data_source"] = {
+        f"{importer.default_data_source}": "remapped"
+    }
+
+    data_source = importer._import_data_source(importer.default_data_source)
+
+    data_source_model = get_data_source_model()
+    qs = data_source_model.objects.all()
+    assertQuerysetEqual(qs, [repr(data_source)])
+    assert data_source.id == "remapped"
+
+
+@pytest.mark.django_db
+def test_import_data(importer):
+    importer.import_data()
+    data_source_model = get_data_source_model()
+    assert Organization.objects.count() == 6
+    assert data_source_model.objects.count() == 1
+    assert OrganizationClass.objects.count() == 5
+
+
+@pytest.mark.django_db
+def test_import_organization_data(importer):
+    importer.import_data()
+
+    organization = Organization.objects.get(
+        id=f"{importer.default_data_source}:{org_kanslia['origin_id'].lower()}"
+    )
+    assert organization.name == org_kanslia["name_fi"]
+    assert (
+        organization.classification.id
+        == f"{importer.default_data_source}:packaged_service"
+    )
+    assert organization.data_source.id == f"{importer.default_data_source}"
+    assert organization.origin_id == org_kanslia["origin_id"].lower()
+    assert organization.founding_date == datetime.date(2018, 1, 15)
+    assert organization.dissolution_date is None
+
+
+@pytest.mark.django_db
+def test_import_organization_data_with_remapped_data_source(importer):
+    importer.config["rename_data_source"] = {
+        f"{importer.default_data_source}": "remapped"
+    }
+
+    importer.import_data()
+
+    organization = Organization.objects.get(
+        id=f"remapped:{org_kanslia['origin_id'].lower()}"
+    )
+    assert organization.name == org_kanslia["name_fi"]
+    assert organization.classification.id == "remapped:packaged_service"
+    assert organization.data_source.id == "remapped"
+    assert organization.origin_id == org_kanslia["origin_id"].lower()
+    assert organization.founding_date == datetime.date(2018, 1, 15)
+    assert organization.dissolution_date is None
+
+
+@pytest.mark.django_db
+def test_import_organization_with_parent(importer):
+    importer.import_data()
+
+    org_child = Organization.objects.get(
+        id=f"{importer.default_data_source}:{org_kanslia['origin_id'].lower()}"
+    )
+    org_parent = Organization.objects.get(
+        id=f"{importer.default_data_source}:{org_4['origin_id'].lower()}"
+    )
+    assert org_child.parent == org_parent
+
+
+@pytest.mark.django_db
+def test_import_organization_without_parent(importer):
+    organization = importer._import_organization(org_1)
+
+    qs = Organization.objects.all()
+    assertQuerysetEqual(qs, [repr(organization)])
+    assert organization.name == org_1["name_fi"]
+    assert (
+        organization.id
+        == f"{importer.default_data_source}:{org_1['origin_id'].lower()}"
+    )
+
+
+@pytest.mark.django_db
+def test_import_organization_flip_parents(importer):
+    """Create organization with different parent organization than in the data and
+    check that importing updates the parent organization."""
+    organization_kanslia = OrganizationFactory(
+        name="existing-organization",
+        origin_id=org_kanslia["origin_id"].lower(),
+        data_source=importer._import_data_source(importer.default_data_source),
+    )
+
+    organization_4 = OrganizationFactory(
+        name="existing-organization",
+        origin_id=org_4["origin_id"].lower(),
+        data_source=importer._import_data_source(importer.default_data_source),
+        parent=organization_kanslia,
+    )
+
+    importer.import_data()
+
+    organization_kanslia.refresh_from_db()
+    organization_4.refresh_from_db()
+
+    assert organization_kanslia.parent == organization_4
+
+
+@pytest.mark.django_db
+def test_import_organization_update_existing(importer):
+    organization = OrganizationFactory(
+        name="existing-organization",
+        origin_id=org_kanslia["origin_id"].lower(),
+        data_source=importer._import_data_source(importer.default_data_source),
+    )
+
+    importer._import_organization(org_kanslia)
+
+    organization.refresh_from_db()
+    assert organization.name == org_kanslia["name_fi"]
+    assert (
+        organization.classification.id
+        == f"{importer.default_data_source}:packaged_service"
+    )
+    assert organization.parent.name == org_4["name_fi"]
+    assert organization.dissolution_date is None
+    assert organization.founding_date == datetime.date(2018, 1, 15)
+
+
+@pytest.mark.parametrize("skip_classifications", [True, False])
+@pytest.mark.django_db
+def test_import_organization_data_with_skip_classifications(
+    importer, skip_classifications
+):
+    """Organization is not imported if it's in the classification skip list."""
+    if skip_classifications:
+        importer.config["skip_classifications"] = ["city"]
+
+    importer.import_data()
+
+    assert (
+        Organization.objects.filter(origin_id__iendswith=org_1["origin_id"]).count()
+        == 0
+        if skip_classifications
+        else 1
+    )
+
+
+@pytest.mark.parametrize(
+    "value,unwrap,expected",
+    [
+        ([], True, None),
+        (["identifier"], True, "identifier"),
+        (["identifier1", "identifier2"], True, "identifier1"),
+        ([], False, []),
+        (["identifier"], False, ["identifier"]),
+        (["identifier1", "identifier2"], False, ["identifier1", "identifier2"]),
+    ],
+)
+def test_get_field_value_unwrap(importer, value, unwrap, expected):
+    config = {"unwrap_list": unwrap}
+    value = importer._get_field_value({"origin_id": value}, "origin_id", config)
+    assert value == expected
+    if expected is None:
+        assert value is None
+
+
+@pytest.mark.parametrize(
+    "value,unquote,expected",
+    [("a%3Ab%25c%23d", True, "a:b%c#d"), ("a%3Ab%25c%23d", False, "a%3Ab%25c%23d")],
+)
+def test_get_field_value_unquote(importer, value, unquote, expected):
+    config = {
+        "unquote": unquote,
+    }
+    value = importer._get_field_value({"origin_id": value}, "origin_id", config)
+    assert value == expected
+
+
+@pytest.mark.django_db
+def test_get_field_value_org_id_regex_data_type(importer):
+    """Parses organization id from a string using regex pattern."""
+    config = {
+        "source_field": "parents",
+        "data_type": "org_id_regex",
+        "unwrap_list": True,
+        "unquote": True,
+        "optional": True,
+    }
+
+    # test raise DataImportError if no pattern is provided
+    with pytest.raises(DataImportError):
+        importer._get_field_value(org_2, "parent", config)
+
+    config["pattern"] = r"\/(\w+:\w+)\/$"
+
+    # This should import the parent organization
+    value = importer._get_field_value(org_2, "parent", config)
+    assert isinstance(value, Organization)
+    assert value.name == org_1["name_fi"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from django_orghierarchy.models import Organization
+
 from .factories import DataSourceFactory, OrganizationClassFactory, OrganizationFactory
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from django_orghierarchy.utils import get_data_source_model, swapper
 from django_orghierarchy.models import DataSource
+from django_orghierarchy.utils import get_data_source_model, swapper
 
 
 class TestGetDataSourceModel(TestCase):


### PR DESCRIPTION
This PR adds an importer for Open Aho API.

- https://dev.hel.fi/apis/openahjo
- https://dev.hel.fi/paatokset/v1/organization/
- https://github.com/City-of-Helsinki/openahjo

This consisted of adding configuration `openahjo` and new configuration options for `RestAPIImporter`.

General configuration: 
- `skip_classifications`: List of organization classifications which will cause organizations of this type to be skipped upon import.
- `has_meta`:  Does the JSON contain a separate object for pagination. 

New field configuration options
- `unquote`: Should the value be run through urllib.parse.unquote.
- `unwrap_list`: Value is wrapped inside of a list. Return the first value on the list.

New field data type:
- `org_id_regex`: Works like org_id and regex data types combined. Extracts the organization identifier using a regexp pattern.

Example for using this imported:

```bash
python manage.py import_organizations https://dev.hel.fi/paatokset/v1/organization/?limit=1000 -c openahjo -s OpenAhjoAPI:ahjo
```

Some additional things included in this PR:
- Running `flake8` and `isort` are enabled in CI configuration. Their configuration is also adjusted and code is formatted to pass the checks.
- Add default timeouts to request get calls 
- `OrganizationClass` import will respect `rename_data_source` source setting when setting `id` for an object.
- `OrganizationClass` instances will have a default name (their `id`) if name is not provided in the data. Also fix an issue where the name was used for filtering when doing `get_or_create` for `OrganizationClass`.
- Imported organizations are cached during a single import run. This will improve the performance when recursively importing parents of a single organization.

