### PR TITLE
feat: move inline styles into a style file

### DIFF
--- a/django_orghierarchy/admin.py
+++ b/django_orghierarchy/admin.py
@@ -200,6 +200,10 @@ class OrganizationAdmin(DraggableMPTTAdmin):
     list_display = (*DraggableMPTTAdmin.list_display, "identifier", "classification_id")
     list_filter = ("data_source",)
 
+    class Media:
+        css = {"all": ["django_orghierarchy/css/admin.css"]}
+        js = ["django_orghierarchy/js/admin.js"]
+
     # these fields may not be changed at all in existing organizations
     existing_readonly_fields = ("id", "data_source", "origin_id", "internal_type")
     # these fields may not be changed at all in protected organizations
@@ -280,17 +284,21 @@ class OrganizationAdmin(DraggableMPTTAdmin):
         obj.save()
 
     def indented_title(self, item):
-        """
-        Override base method to add custom styles for affiliated organizations
-        """
-        additional_styles = ""
-        if item.internal_type == Organization.AFFILIATED:
-            additional_styles = "color: red;"
-
+        level = item._mpttfield("level")
+        extra_class = (
+            " orghierarchy-affiliated"
+            if item.internal_type == Organization.AFFILIATED
+            else ""
+        )
+        template = (
+            '<div class="orghierarchy-indent{}"'
+            ' data-indent-level="{}" data-indent-size="{}">{}</div>'
+        )
         return format_html(
-            '<div style="text-indent:{}px; {}">{}</div>',
-            item._mpttfield("level") * self.mptt_level_indent,
-            additional_styles,
+            template,
+            extra_class,
+            level,
+            self.mptt_level_indent,
             item,
         )
 

--- a/django_orghierarchy/static/django_orghierarchy/css/admin.css
+++ b/django_orghierarchy/static/django_orghierarchy/css/admin.css
@@ -1,0 +1,7 @@
+/* Organization tree indentation - driven by --orghierarchy-indent set via JS from data-indent-level/data-indent-size */
+.orghierarchy-indent {
+    padding-left: var(--orghierarchy-indent, 0px);
+}
+
+/* Affiliated organization highlight */
+.orghierarchy-affiliated { color: red; }

--- a/django_orghierarchy/static/django_orghierarchy/js/admin.js
+++ b/django_orghierarchy/static/django_orghierarchy/js/admin.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".orghierarchy-indent[data-indent-level]").forEach(function (el) {
+        const level = Number.parseInt(el.dataset.indentLevel, 10);
+        const size = Number.parseInt(el.dataset.indentSize, 10) || 20;
+        el.style.setProperty("--orghierarchy-indent", (level * size) + "px");
+    });
+});

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -608,8 +608,14 @@ class TestOrganizationAdmin(TestCase):
         request = self.factory.get("/fake-url/")
         request.user = self.admin
 
-        self.assertNotIn("color: red;", oa.indented_title(self.organization))
-        self.assertIn("color: red;", oa.indented_title(self.affiliated_organization))
+        title = oa.indented_title(self.organization)
+        self.assertIn('class="orghierarchy-indent"', title)
+        self.assertIn('data-indent-level="', title)
+        self.assertIn('data-indent-size="', title)
+        self.assertNotIn("orghierarchy-affiliated", title)
+
+        affiliated_title = oa.indented_title(self.affiliated_organization)
+        self.assertIn("orghierarchy-affiliated", affiliated_title)
 
     def test_has_change_permission(self):
         normal_admin = make_admin(username="normal_admin", is_superuser=False)


### PR DESCRIPTION
This is more CSP friendly because it doesn't require additional unsafe-inline declarations for all the possible indentations.

Refs: RATYK-207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Admin UI / Styling**
  - Updated the organization tree rendering to remove inline-styled markup and instead use CSS classes with `data-indent-*` attributes.
  - Affiliated organizations now receive distinct visual emphasis.
  - Added admin CSS for indentation and highlighting, plus a page-load script that calculates indentation dynamically from the attributes.

- **Tests**
  - Updated admin tests to verify the new indentation attributes/classes and the affiliated vs non-affiliated rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->